### PR TITLE
Run shell as default if no arguments are given upon docker run

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 source /venv/bin/activate
-exec "$@"
-exec bash
+if [ $# -eq 0 ]; then
+    exec bash
+else
+    exec "$@"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 source /venv/bin/activate
 exec "$@"
+exec bash


### PR DESCRIPTION
Added `exec bash` at the end of the` entrypoint.sh`. This will help `docker run` command to run open bash 