### PR TITLE
add Mirror fix & Mirror protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
-# Use the texlive/texlive image as the base image
 FROM texlive/texlive:latest
 
-# Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV VENV_PATH=/venv
 
-# Install Python and dependencies
+# Fix DNS or HTTP-related fetch issues first
+RUN find /etc/apt/sources.list.d -name "*.list" -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + && \
+    apt-get update && \
+    apt-get install -y curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Python
 RUN apt-get update && \
     apt-get install -y python3 python3-pip python3-venv && \
     rm -rf /var/lib/apt/lists/*
 
-# Create and activate a Python virtual environment
+# Create virtual environment
 RUN python3 -m venv $VENV_PATH
 
-# Install Python dependencies
+# Install Python packages
 COPY requirements.txt /app/
 RUN $VENV_PATH/bin/pip install --upgrade pip setuptools wheel && \
     $VENV_PATH/bin/pip install -r /app/requirements.txt


### PR DESCRIPTION
Updated the mirror URLs from http to https in files under /etc/apt/sources.list.d/ (since /etc/apt/sources.list doesn’t exist).
Installed curl and ca-certificates first to avoid network-related issues.
Re-ordered and split some steps for better reliability and clarity.