### PR TITLE
Normalize line endings and fix package list parsing for Windows compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Set default line endings to LF for all text files
+* text=auto eol=lf
+
+# Explicitly set LF for specific file types
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.py text eol=lf
+*.jinja text eol=lf
+*.tex text eol=lf
+*.cls text eol=lf
+*.yaml text eol=lf
+*.bib text eol=lf
+*.md text eol=lf
+.gitignore text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 output/
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Start a Docker container with the image you just built. This will launch an inte
 $ docker run -it -v $(pwd):/workdir cv-tools
 ```
 
+for windows systems:
+```bash
+$ docker run -it -v $(pwd -W):/workdir cv-tools
+```
+
 The `-v $(pwd):/workdir` option mounts your local cv-tools directory to the `/workdir` directory inside the container.
 
 ### Method 2: From Source with Manual Installation

--- a/run.sh
+++ b/run.sh
@@ -64,7 +64,7 @@ check_latex_package() {
 check_latex_packages_from_file() {
     local package_file="$1"
     while IFS= read -r package || [ -n "$package" ]; do
-        package=$(echo "$package" | xargs)  # Trim any surrounding whitespace
+        package=$(echo "$package" | tr -d '\r' | xargs)  # Trim whitespace and strip CR
         if [ -n "$package" ]; then
             check_latex_package "$package"
         fi


### PR DESCRIPTION
This PR fixes an issue where packages in packages.list may contain Windows-style carriage returns (\r), causing tlmgr to fail. It trims whitespace and CR characters using tr -d '\r' | xargs (run.sh). Also, the readme was update to include windows direction handling and addes a .gitattirbute file to standarize line endings